### PR TITLE
Fix: Add initial delay to health check in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,7 @@ jobs:
     - name: Verify deployment
       run: |
           echo "Waiting for container to become ready..."
+          sleep 10 # <-- ADD THIS LINE
           MAX_RETRIES=20
           SLEEP_TIME=3
           for i in $(seq 1 $MAX_RETRIES); do


### PR DESCRIPTION
The health check in the "Deploy to Production" workflow was failing intermittently because it might have been running before the application container was fully initialized and ready to accept connections.

This change introduces an initial 10-second delay before the health check loop begins. This allows the container more time to start up, reducing the likelihood of premature health check failures. The existing retry mechanism (20 retries with 3 seconds sleep) remains in place.